### PR TITLE
Increase export page size to 5k.

### DIFF
--- a/backend/api.ts
+++ b/backend/api.ts
@@ -92,7 +92,7 @@ function exportMerchantCenterReport(
       fetchAll: true,
       payload: {
         query: query,
-        pageSize: 1000,
+        pageSize: 5000,
       },
     };
     const response = api.getReport(request);

--- a/backend/tests/api.test.ts
+++ b/backend/tests/api.test.ts
@@ -140,7 +140,7 @@ describe('API functions', () => {
       fetchAll: true,
       payload: {
         query: mockQuery,
-        pageSize: 1000,
+        pageSize: 5000,
       },
     });
     expect(mockMerchantCenterAPI.prototype.flatten).toHaveBeenCalledWith(


### PR DESCRIPTION
The maximum page size is 5k not 1k, so increase the export size to reduce calls and speed up execution.